### PR TITLE
Python 3 compatibility

### DIFF
--- a/curlify.py
+++ b/curlify.py
@@ -1,4 +1,20 @@
 # coding: utf-8
+import sys
+
+PY2 = sys.version_info[0] == 2
+
+if not PY2:  # From https://github.com/flask-admin/flask-admin/blob/master/flask_admin/_compat.py (License BSD) 
+    def as_unicode(s):
+        if isinstance(s, bytes):
+            return s.decode('utf-8')
+
+
+else:
+    def as_unicode(s):
+        if isinstance(s, str):
+            return s.decode('utf-8')
+
+        return unicode(s)  # NOQA: F82
 
 
 def to_curl(request, compressed=False, verify=True):
@@ -10,18 +26,13 @@ def to_curl(request, compressed=False, verify=True):
     compressed : bool
         If `True` then `--compressed` argument will be added to result
     """
-    parts = [
-        ('curl', None),
-        ('-X', request.method),
-    ]
+    parts = [('curl', None), ('-X', request.method)]
 
     for k, v in sorted(request.headers.items()):
-        parts += [('-H', '{0}: {1}'.format(k, v))]
+        parts += [('-H', '{0}: {1}'.format(as_unicode(k), as_unicode(v)))]
 
     if request.body:
-        body = request.body
-        if isinstance(body, bytes):
-            body = body.decode('utf-8')
+        body = as_unicode(request.body)
         parts += [('-d', body)]
 
     if compressed:


### PR DESCRIPTION
Fixes issues with Python 3.x encoding the request.headers in `b''`

Version: 2.19.1